### PR TITLE
Add upgrade and python playbooks to prepare playbook

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,6 @@
+---
+- name: Import upgrade playbook
+  import_playbook: upgrade.yml
+
+- name: Import python playbook
+  import_playbook: python.yml

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  name: Install pip3/python3 and remove pip2/python2
+  become: yes
+  become_method: sudo
+  roles:
+    - pip
+    - python
+    - remove_python2

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,8 @@
+- src: https://github.com/cisagov/ansible-role-pip
+  name: pip
+- src: https://github.com/cisagov/ansible-role-python
+  name: python
+- src: https://github.com/cisagov/ansible-role-remove-python2
+  name: remove_python2
+- src: https://github.com/cisagov/ansible-role-upgrade
+  name: upgrade

--- a/molecule/default/upgrade.yml
+++ b/molecule/default/upgrade.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  name: Upgrade base image
+  become: yes
+  become_method: sudo
+  roles:
+    - upgrade


### PR DESCRIPTION
## 🗣 Description

In this pull request I import into the molecule prepare playbook the upgrade and python playbooks that we normally use to prepare a base AMI when we run packer.

## 💭 Motivation and Context

Doing this upgrades the base image, installs python3/pip3, and removes python2/pip2.  This leaves the base image in a state just like it would be if we were building an AMI via packer, and is a much more realistic canvas on which to perform our molecule tests.

This Ansible role was failing to build and needed to have `apt-get update` run on it in order to start working again.  The more comprehensive fix I implemented here is something I have been thinking about for a while, and so I went ahead and did it.  If everyone agrees, I will add these changes to [skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role).

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
